### PR TITLE
Update to Feathers Buzzard (v3)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,10 @@
 const Proto = require('uberproto');
-const filter = require('feathers-query-filters');
-const errors = require('feathers-errors');
-
-const { _, select, hooks } = require('feathers-commons');
-const { processHooks, getHooks } = require('feathers-hooks/lib/commons');
+const { _, select, hooks, filterQuery } = require('@feathersjs/commons');
+const errors = require('@feathersjs/errors');
 
 const { createFilter } = require('./parse');
 
+const { processHooks, getHooks, createHookObject } = hooks;
 const BASE_EVENTS = ['created', 'updated', 'patched', 'removed'];
 
 // Create the service.
@@ -69,7 +67,7 @@ class Service {
   }
 
   createQuery (originalQuery) {
-    const { filters, query } = filter(originalQuery || {});
+    const { filters, query } = filterQuery(originalQuery || {});
 
     let r = this.options.r;
     let rq = this.table.filter(this.createFilter(query));
@@ -96,7 +94,7 @@ class Service {
   _find (params = {}) {
     const paginate = typeof params.paginate !== 'undefined' ? params.paginate : this.paginate;
     // Prepare the special query params.
-    const { filters } = filter(params.query || {}, paginate);
+    const { filters } = filterQuery(params.query || {}, paginate);
 
     let q = params.rethinkdb || this.createQuery(params.query);
     let countQuery;
@@ -279,6 +277,7 @@ class Service {
           app,
           service,
           result: data,
+          type: 'after',
           get path () {
             return Object.keys(app.services)
               .find(path => app.services[path] === service);
@@ -295,7 +294,7 @@ class Service {
           args.unshift(data[this.id]);
         }
 
-        const hookObject = hooks.hookObject(method, 'after', args, hookData);
+        const hookObject = createHookObject(method, args, hookData);
         const hookChain = getHooks(app, this, 'after', method);
 
         return processHooks.call(this, hookChain, hookObject);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,4 +1,4 @@
-const { _ } = require('feathers-commons');
+const { _ } = require('@feathersjs/commons');
 
 // Special parameter to RQL condition
 const mappings = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,19 +4,65 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "8.0.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==",
-      "dev": true
+    "@feathersjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-/2Fevm/g0hIe79A81eMOScPNtoWIuHk1LwXCLJGeuGKoTUnzd/xJLSFesSq7dlePDtwMtuR8apnB1CM49iCy+g=="
     },
-    "@types/socket.io": {
-      "version": "1.4.31",
-      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-1.4.31.tgz",
-      "integrity": "sha512-HnO78rKiAx+tCEKYFurJvKLNAluN9B0V+yLnkJEY9BVwmCXHA7oKeLCymqP/uAgx0t+un/JM+GJOTwNQJ+ODvQ==",
+    "@feathersjs/errors": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.2.0.tgz",
+      "integrity": "sha512-4xsE7OyzxGvs2hyG19nf2qb4rV2nWoWbQ6/FnDIYrNHi7M9kOy+deLwNhKnXa4r/hg3xf+AVpC8kBjUQjWYWHA==",
+      "requires": {
+        "debug": "3.1.0"
+      }
+    },
+    "@feathersjs/express": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@feathersjs/express/-/express-1.1.2.tgz",
+      "integrity": "sha512-oxXZs3QAZB80fBajb7nh3Pbongm8ESXVnJw1EuX7fui4JOXh2qGw9hf8e3xKAZ/fmkHmgofdA1A3iqIzBg3Isw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.53"
+        "@feathersjs/commons": "1.3.0",
+        "@feathersjs/errors": "3.2.0",
+        "debug": "3.1.0",
+        "express": "4.16.2",
+        "uberproto": "1.2.0"
+      }
+    },
+    "@feathersjs/feathers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/feathers/-/feathers-3.0.1.tgz",
+      "integrity": "sha512-uRvzpnpwdW31+hQ67sGPQAQm09hmZrw1nc5om9yoSTouszjREcM2qusJkyWXN67/8Uythge6OjlYIP0NFJHVaw==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/commons": "1.3.0",
+        "debug": "3.1.0",
+        "events": "1.1.1",
+        "uberproto": "1.2.0"
+      }
+    },
+    "@feathersjs/socket-commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socket-commons/-/socket-commons-3.0.1.tgz",
+      "integrity": "sha512-/WgXC7tODg16uCGK5SKQYg3NvCdchJQyvBD1F0ljKWCee8N+Ep5TprN+i0/Ip4hAwWsQMQ7HIKBKdDvJ32aYyA==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/errors": "3.2.0",
+        "debug": "3.1.0",
+        "lodash": "4.17.4",
+        "url-pattern": "1.0.3"
+      }
+    },
+    "@feathersjs/socketio": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/socketio/-/socketio-3.0.1.tgz",
+      "integrity": "sha512-YZFpj52tu1QrO/n74CyeceCZ20dr3CIN6cGYHTbvl+As+aNY7yzQTvUVKBOrOfLUu/tuI4u1W+BzH+30+9ySSA==",
+      "dev": true,
+      "requires": {
+        "@feathersjs/socket-commons": "3.0.1",
+        "debug": "3.1.0",
+        "socket.io": "2.0.4"
       }
     },
     "abbrev": {
@@ -1455,63 +1501,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "feathers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/feathers/-/feathers-2.2.3.tgz",
-      "integrity": "sha512-p2dgIbhD5IBZRN2At2hahg0KHnyRLIL0sQE+5Ci+GlAHPEQtAVUSgfWqTAOMiNFelHUqlFZSREnXH0VsuV3NOw==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "debug": "3.1.0",
-        "events": "1.1.1",
-        "express": "4.16.2",
-        "feathers-commons": "0.8.7",
-        "rubberduck": "1.1.1",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-commons": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/feathers-commons/-/feathers-commons-0.8.7.tgz",
-      "integrity": "sha1-EcbyW1N3RamD6NYVUtfbiTLVN4I="
-    },
-    "feathers-errors": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/feathers-errors/-/feathers-errors-2.9.2.tgz",
-      "integrity": "sha512-qwIX97bNW7+1tWVG073+omUA0rCYKJtTtwuzTrrvfrtdr8J8Dk1Fy4iaV9Fa6/YBD5AZu0lsplPE0iu4u/d4GQ==",
-      "requires": {
-        "debug": "3.1.0"
-      }
-    },
-    "feathers-hooks": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/feathers-hooks/-/feathers-hooks-2.1.2.tgz",
-      "integrity": "sha512-XQKhbo4d4TuXyco+tbHmKn5wo8QhdSNslJ/+zckNYfUzLmrN8L3uB4Utf0/ivcgwWxJtS1kVhEETBN4TDxuWFg==",
-      "requires": {
-        "feathers-commons": "0.8.7",
-        "uberproto": "1.2.0"
-      }
-    },
-    "feathers-query-filters": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/feathers-query-filters/-/feathers-query-filters-2.1.2.tgz",
-      "integrity": "sha1-zbGCJNteGcwBQNUoEI4JCNXrBlQ=",
-      "requires": {
-        "feathers-commons": "0.8.7"
-      }
-    },
-    "feathers-rest": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/feathers-rest/-/feathers-rest-1.8.1.tgz",
-      "integrity": "sha512-FYVcBQLGocSdpjxEf+E/9Cb0QAX0S+biqRgB5KAGpoAF51cou9LV0WW1IwqwHzAT67KRyS4dT7fVCrE4kisM2w==",
-      "dev": true,
-      "requires": {
-        "debug": "3.1.0",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2",
-        "qs": "6.5.1"
-      }
-    },
     "feathers-service-tests": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/feathers-service-tests/-/feathers-service-tests-0.10.2.tgz",
@@ -1557,41 +1546,6 @@
           "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
           "dev": true
         }
-      }
-    },
-    "feathers-socket-commons": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/feathers-socket-commons/-/feathers-socket-commons-2.4.0.tgz",
-      "integrity": "sha1-Bi79V/mocWZEFFuZOl9ycJlp8eE=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "feathers-commons": "0.8.7",
-        "feathers-errors": "2.9.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "feathers-socketio": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/feathers-socketio/-/feathers-socketio-2.0.1.tgz",
-      "integrity": "sha512-3ByXVr6UGyGN6TPRN+U5IhENYrSgeuADhbKWLG5cq2WvYH9h2N1l3cj7WBVsfRektUgVw/HkGNAoExy8yuknMA==",
-      "dev": true,
-      "requires": {
-        "@types/socket.io": "1.4.31",
-        "debug": "3.1.0",
-        "feathers-socket-commons": "2.4.0",
-        "socket.io": "2.0.4",
-        "uberproto": "1.2.0"
       }
     },
     "figures": {
@@ -3101,12 +3055,6 @@
         "glob": "7.1.2"
       }
     },
-    "rubberduck": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rubberduck/-/rubberduck-1.1.1.tgz",
-      "integrity": "sha1-zSzaS4ZxeBNer8mVpxOE9fdD2wI=",
-      "dev": true
-    },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
@@ -3636,6 +3584,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "url-pattern": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/url-pattern/-/url-pattern-1.0.3.tgz",
+      "integrity": "sha1-BAkpJHGyTyPFDWWkeTF5PStaz8E=",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -46,21 +46,18 @@
     "lib": "lib"
   },
   "dependencies": {
-    "debug": "^3.0.1",
-    "feathers-commons": "^0.8.4",
-    "feathers-errors": "^2.0.2",
-    "feathers-hooks": "^2.0.2",
-    "feathers-query-filters": "^2.0.0",
+    "@feathersjs/commons": "^1.3.0",
+    "@feathersjs/errors": "^3.2.0",
+    "debug": "^3.1.0",
     "uberproto": "^1.2.0"
   },
   "devDependencies": {
+    "@feathersjs/express": "^1.1.2",
+    "@feathersjs/feathers": "^3.0.1",
+    "@feathersjs/socketio": "^3.0.1",
     "body-parser": "^1.15.0",
     "chai": "^4.0.0",
-    "feathers": "^2.0.0",
-    "feathers-hooks": "^2.0.1",
-    "feathers-rest": "^1.2.4",
     "feathers-service-tests": "^0.10.0",
-    "feathers-socketio": "^2.0.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^4.0.0",
     "rethinkdbdash": "^2.2.18",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,8 @@
 const chai = require('chai');
 const { base } = require('feathers-service-tests');
 
-const feathers = require('feathers');
-const errors = require('feathers-errors');
-const hooks = require('feathers-hooks');
+const feathers = require('@feathersjs/feathers');
+const errors = require('@feathersjs/errors');
 const rethink = require('rethinkdbdash');
 const service = require('../lib');
 
@@ -45,7 +44,6 @@ const numberService = {
 };
 
 const app = feathers()
-  .configure(hooks())
   .use('/people', service({
     Model: r,
     name: 'people',


### PR DESCRIPTION
This updates the development dependencies to Feathers Buzzard. New release will stay compatible with previous versions of Feathers.

Previous versions of `feathers-rethinkdb` are also compatible with Feathers Buzzard.